### PR TITLE
fix: pin aws cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update \
   && rm -rf /var/cache/apk/* \
   && pip3 install --upgrade pip \
   && pip3 install pyyaml==5.3.1 \
-  && pip3 install -U awscli \
+  && pip3 install -U awscli==1.44.38 \
   && apk --purge -v del py3-pip
 
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Fixes `Error response from daemon: client version 1.42 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version`